### PR TITLE
fix: force uuid >=11.1.1 to address CVE-2026-41907

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ npm run build
 npm run preview
 ```
 
+There is no ESLint configured — "linting" for this project means running `tsc --noEmit`.
+
 ## Architecture
 
 ### Dual-Mode Application
@@ -34,55 +36,94 @@ The app has two distinct entry modes controlled by URL parameters:
 - **Plugin Mode**: When `?obrref` is present in URL, renders the full plugin wrapped in `<PluginGate>` that waits for Owlbear Rodeo SDK to be ready
 - **Homepage Mode**: Without `?obrref`, renders a static homepage for marketing/info purposes
 
-Entry point: `src/main.tsx:14-24`
+Entry point: `src/main.tsx`
+
+The plugin ID `"es.memorablenaton.shadowcrawler"` is exported as `ID` from `src/main.tsx` and imported by `Main.tsx` to prefix all OBR broadcast channel names.
 
 ### Owlbear Rodeo Integration
 
 The app uses `@owlbear-rodeo/sdk` for integration with Owlbear Rodeo:
 
-- **Scene Ready Check**: App waits for OBR scene to be ready before rendering main UI (`src/components/App.tsx:11-12`)
-- **Player Roles**: Detects if user is GM or PLAYER and renders different views accordingly (`src/components/SPA.tsx:17-19,37-38`)
-- **Broadcast Messages**: Uses OBR's broadcast system for real-time sync between GM and players (countdown, torch turns, visibility state)
-- **Theme Sync**: Automatically syncs with OBR's light/dark theme (`src/components/SPA.tsx:31-36`)
+- **Scene Ready Check**: App waits for OBR scene to be ready before rendering main UI (`src/components/App.tsx`)
+- **Player Roles**: Detects if user is GM or PLAYER and passes a `player` boolean prop to `Main.tsx`, which renders different views accordingly
+- **Broadcast Messages**: Uses OBR's broadcast system for real-time sync between GM and players
+- **Theme Sync**: OBR's light/dark theme is applied by toggling the `dark` class on `<html>` in `SPA.tsx`
 
-Message channels used (all prefixed with plugin ID):
+OBR broadcast channels (all prefixed with `ID`):
 
-- `${ID}-countdown`: Current countdown value
-- `${ID}-mode`: Timer mode (1h vs 10 turns)
+- `${ID}-countdown`: Current countdown value in seconds
+- `${ID}-mode`: Timer mode (`"1h"` vs `"10turns"`)
 - `${ID}-torchTurn`: Current torch turn number
-- `${ID}-show-to-players`: Visibility toggle
+- `${ID}-show-to-players`: Visibility toggle boolean
+
+### Routing
+
+Uses `react-router-dom` v6. Routes are defined in `SPA.tsx` with `Navbar.tsx` as the layout wrapper (renders tabs + `<Outlet />`):
+
+- `/` — `Main.tsx` (GM/player game interface)
+- `/about` — `About.tsx` (theme selector, social links, version, donation buttons)
+
+Route paths are defined in `src/components/util/constants.ts`.
 
 ### Component Structure
 
-- **Main.tsx**: Core GM interface with torch timer, crawling turns counter, and random encounter roller. Manages all game state and broadcasts to players
-- **PlayerView.tsx**: Simple view shown to players when GM hasn't enabled "show to players"
-- **SPA.tsx**: Router setup, role detection, and theme management
-- **PluginGate.tsx**: Wrapper that ensures OBR SDK is ready before rendering children
+- **Main.tsx**: Core GM/player interface. Manages all game state, persists to localStorage, and broadcasts to players via OBR
+- **SPA.tsx**: Sets up router, detects player role, syncs OBR theme to `dark` CSS class
+- **Navbar.tsx**: Tab navigation (Main / About), renders the `WhatsNew` modal, shows dev mode banner
+- **About.tsx**: Hosts `ThemeSelector`, social links, `DonationButtons`, and version display
+- **ThemeSelector.tsx**: UI for switching between the 4 color palettes defined in `src/themes.ts`
+- **WhatsNew.tsx**: Modal that shows release highlights when the version in `manifest.json` is newer than what's stored in localStorage
+- **PluginGate.tsx**: Waits for OBR SDK to be ready before rendering children
+- **OBRLoading.tsx**: Loading state shown while OBR initialises
+- **SceneNotReady.tsx**: Shown when OBR scene is not yet ready
+- **PlayerView.tsx**: Placeholder view shown to players when GM has not enabled "show to players"
 - **Homepage.tsx**: Standalone landing page (non-plugin mode)
 
 ### State Management
 
 The app uses local component state (React hooks) with localStorage persistence:
 
-- State is saved to localStorage on every change (`src/components/Main.tsx:141-152`)
-- State is loaded from localStorage on mount (`src/components/Main.tsx:154-166`)
-- State includes: mode, countdown, torchTurn, crawlingTurns, showToPlayers, randomEncounterRoll, randomEncounterTurn
+- State is saved to localStorage on every change and loaded on mount (`src/components/Main.tsx`)
+- State includes: `mode`, `countdown`, `torchTurn`, `crawlingTurns`, `showToPlayers`, `randomEncounterRoll`, `randomEncounterTurn`
 
-No global state management library is used. State is synchronized between GM and players via OBR broadcast messages.
+No global state management library is used. State is synchronised between GM and players via OBR broadcast messages.
+
+localStorage keys used across the app:
+
+- `shadowcrawlerState` — main game state (Main.tsx)
+- `map-location-keys-theme` — user's selected color palette (useTheme.ts)
+- `shadowcrawler-last-seen-version` — last version seen, drives WhatsNew modal (Navbar.tsx)
+
+### Theming
+
+Two independent layers:
+
+1. **OBR color mode** (`light` / `dark`): controlled by Owlbear Rodeo. Applied by toggling the `dark` class on `<html>`, enabling Tailwind's `dark:` variants.
+2. **Color palette**: 4 user-selectable themes defined in `src/themes.ts` (`dark-fantasy`, `modern-saas`, `gaming-vibrant`, `earthy-dungeon`). The active theme is applied as CSS custom properties (`--color-bg`, `--color-primary`, etc.) on `:root` by `src/hooks/useTheme.ts`. Components use these via Tailwind's `bg-[var(--color-bg)]` syntax or direct `style` props.
+
+### Icons
+
+Both inline SVG and FontAwesome icons (`@fortawesome/react-fontawesome`) are used across components.
+
+### Analytics
+
+`src/utils.ts` exposes an `analytics` object that wraps `window.gtag` calls. Events are tracked for timer interactions, mode changes, and other key actions. The function is a no-op when `gtag` is not available.
+
+### Dev Mode
+
+Setting `localStorage.setItem("dev-mode", "true")` in the browser console activates a yellow "Development Mode" banner rendered by `Navbar.tsx`. Useful for local testing without modifying code.
+
+### Release Notes
+
+`src/releaseNotes.ts` contains the `releaseHighlights` array shown in the `WhatsNew` modal. Add a new entry here when shipping a release.
 
 ### TypeScript Configuration
 
 - Target: ES2020
-- Strict mode enabled with additional linting rules (noUnusedLocals, noUnusedParameters, noFallthroughCasesInSwitch)
+- Strict mode enabled with additional linting rules (`noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`)
 - Module resolution: bundler mode
 - JSX: react-jsx (React 17+ transform)
-- Always run type checking after editing TypeScript files: `tsc --noEmit`
-
-### Styling
-
-- Uses Tailwind CSS v4 with utility classes and `dark:` variants
-- Inline SVG icons
-- Theme (light/dark) controlled by Owlbear Rodeo, toggling `dark` class on `<html>` element
+- Always run `tsc --noEmit` after editing TypeScript files
 
 ### Manifest
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,16 +3111,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "remarkable-react": "^1.4.3"
   },
   "overrides": {
-    "prismjs": "^1.30.0"
+    "prismjs": "^1.30.0",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
## Summary

- `uuid <11.1.1` has a missing buffer bounds check in `v3()`/`v5()`/`v6()` when an external output buffer is provided, allowing silent partial writes ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), CVE-2026-41907)
- `uuid` is a transitive dependency of `@owlbear-rodeo/sdk`, which pins `^9.0.0` — upgrading the SDK to 3.x does not help as it also pins `^9.0.0`
- Added an npm `overrides` entry to force `uuid >=11.1.1` across all dependents, matching the existing pattern used for `prismjs`

Closes https://github.com/alvarocavalcanti/shadowcrawler/security/dependabot/17

## Test plan

- [x] `uuid` in `package-lock.json` is now `11.1.1`
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm audit` no longer reports the uuid vulnerability